### PR TITLE
Migrate 1Password references to Pattern C tenant naming (SHOW-637/638)

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -60,14 +60,14 @@ jobs:
           REGISTRY_REGION: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/registryRegion
           WIF_PROVIDER: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/workloadIdentityProvider
           WIF_SERVICE_ACCOUNT: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/pusherServiceAccount
-          WIZ_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV}}-wizcli-sa/username
-          WIZ_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/password
-          WIZCLI_URL: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/wizcliUrl
-          WIZ_OS_REGISTRY: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'adv-stg' || 'adv-prod' }}-tenant-info/wizOsRegistryUrl
-          WIZ_OS_USER: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'adv-stg' || 'adv-prod' }}-tenant-info/wizOsRegistryUsername
-          WIZ_OS_PASSWORD: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'adv-stg' || 'adv-prod' }}-tenant-info/wizOsRegistryPassword
-          WIZ_OS_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizos-apk-credentials/username
-          WIZ_OS_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizos-apk-credentials/credential
+          WIZ_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/username
+          WIZ_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/password
+          WIZCLI_URL: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/wizcliUrl
+          WIZ_OS_REGISTRY: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryUrl
+          WIZ_OS_USER: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryUsername
+          WIZ_OS_PASSWORD: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryPassword
+          WIZ_OS_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizos-apk-credentials/username
+          WIZ_OS_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizos-apk-credentials/credential
 
 
       - name: Get Wiz CLI SHA256

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -60,14 +60,14 @@ jobs:
           REGISTRY_REGION: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/registryRegion
           WIF_PROVIDER: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/workloadIdentityProvider
           WIF_SERVICE_ACCOUNT: op://wiz-demo/gar_${{ env.DEPLOY_ENV }}-registry/pusherServiceAccount
-          WIZ_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/username
-          WIZ_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/password
-          WIZCLI_URL: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizcli-sa/wizcliUrl
-          WIZ_OS_REGISTRY: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryUrl
-          WIZ_OS_USER: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryUsername
-          WIZ_OS_PASSWORD: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || 'advanced' }}-tenant-info/wizOsRegistryPassword
-          WIZ_OS_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizos-apk-credentials/username
-          WIZ_OS_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV == 'stgadvanced' && 'stg-advanced' || env.DEPLOY_ENV }}-wizos-apk-credentials/credential
+          WIZ_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/username
+          WIZ_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/password
+          WIZCLI_URL: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizcli-sa/wizcliUrl
+          WIZ_OS_REGISTRY: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-tenant-info/wizOsRegistryUrl
+          WIZ_OS_USER: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-tenant-info/wizOsRegistryUsername
+          WIZ_OS_PASSWORD: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-tenant-info/wizOsRegistryPassword
+          WIZ_OS_CLIENT_ID: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizos-apk-credentials/username
+          WIZ_OS_CLIENT_SECRET: op://wiz-demo/tenant_${{ env.DEPLOY_ENV }}-wizos-apk-credentials/credential
 
 
       - name: Get Wiz CLI SHA256

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -3,13 +3,13 @@ name: Build/Scan/Push Containers
 on:
   workflow_dispatch:
     inputs:
-      tenant:
-        description: 'Tenant (overrides branch-based logic)'
+      environment:
+        description: 'Environment (overrides branch-based logic)'
         required: false
         type: choice
         options:
-          - staging
-          - production
+          - advanced
+          - stgadvanced
       versions:
         description: 'WizCLI version to use for scanning'
         required: true


### PR DESCRIPTION
## Summary

Aligns 1Password (`op://`) secret references in this repo with the
canonical tenant short-name naming used across the `wiz-demo` GitHub
org, per SHOW-637/SHOW-638.

## Naming convention

Tenant 1Password items follow `tenant_<tenant-short-name>-<resource>`,
where `<tenant-short-name>` matches the `DEPLOY_ENV` value used in
GitHub Actions workflows (no hyphen for staging-advanced):

- `tenant_advanced-...`     (production tenant)
- `tenant_stgadvanced-...`  (staging tenant)
- `tenant_wizdom-...`, `tenant_wizdemoext-...`, etc.

The previously proposed `tenant_stg-advanced-*` form was reverted in
favor of `tenant_stgadvanced-*` so workflow URIs can use bare
`${{ env.DEPLOY_ENV }}` without a mapping ternary.

## What changed

`op://wiz-demo/tenant_*` references in this workflow now resolve to
the canonical item names. Where this workflow uses `DEPLOY_ENV` to
identify the tenant, URIs use bare `${{ env.DEPLOY_ENV }}`. Legacy
`tenant_adv-*` literals are replaced with their canonical equivalents.

## Test plan

- [ ] CI passes
- [ ] Trigger a staging deploy and confirm `tenant_stgadvanced-*` 1P lookups resolve
- [ ] Trigger a prod deploy and confirm `tenant_advanced-*` lookups resolve